### PR TITLE
moshi使用でAPIレスポンスを受け取れるように修正

### DIFF
--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -39,7 +39,11 @@ dependencies {
     implementation(project(":model"))
 
     /** HTTP Connection */
-    implementation(libs.retrofit2)
+    implementation(libs.bundles.http)
+
+    /** DI */
+    implementation(libs.hilt.android)
+    kapt(libs.hilt.kapt)
 
     /** Timber */
     implementation(libs.timber)

--- a/api/src/main/java/com/example/api/QiitaApi.kt
+++ b/api/src/main/java/com/example/api/QiitaApi.kt
@@ -1,16 +1,11 @@
 package com.example.api
 
 import com.example.model.Article
-import retrofit2.Call
+import retrofit2.Response
 import retrofit2.http.GET
 
 interface QiitaApi {
 
-//    @GET("items")
-//    suspend fun articleItems(
-//        @Query("query") query: String?
-//    ): Call<List<Article>>
-
     @GET("items")
-    suspend fun articleItems(): Call<List<Article>>
+    suspend fun articleItems(): Response<List<Article>>
 }

--- a/api/src/main/java/com/example/di/ApiModule.kt
+++ b/api/src/main/java/com/example/di/ApiModule.kt
@@ -38,16 +38,23 @@ object ApiModule {
 
     @Provides
     @Singleton
-    fun provideRetrofit(
-        okHttpClient: OkHttpClient,
-    ): Retrofit {
+    fun provideMoshi(): MoshiConverterFactory {
         val moshi = Moshi.Builder()
             .add(KotlinJsonAdapterFactory())
             .build()
+        return MoshiConverterFactory.create(moshi)
+    }
+
+    @Provides
+    @Singleton
+    fun provideRetrofit(
+        okHttpClient: OkHttpClient,
+        moshiConverterFactory: MoshiConverterFactory,
+    ): Retrofit {
         return Retrofit.Builder()
             .client(okHttpClient)
             .baseUrl("https://qiita.com/api/v2/")
-            .addConverterFactory(MoshiConverterFactory.create(moshi))
+            .addConverterFactory(moshiConverterFactory)
             .build()
     }
 

--- a/api/src/main/java/com/example/di/ApiModule.kt
+++ b/api/src/main/java/com/example/di/ApiModule.kt
@@ -1,0 +1,58 @@
+package com.example.di
+
+import com.example.api.QiitaApi
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import okhttp3.OkHttpClient
+import okhttp3.logging.HttpLoggingInterceptor
+import retrofit2.Retrofit
+import retrofit2.converter.moshi.MoshiConverterFactory
+import java.util.concurrent.TimeUnit
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object ApiModule {
+
+    @Provides
+    @Singleton
+    fun provideOkhttpClient(): OkHttpClient {
+        val logInterceptor = HttpLoggingInterceptor()
+        logInterceptor.level = HttpLoggingInterceptor.Level.BODY
+
+        return OkHttpClient.Builder()
+            .addInterceptor {
+                val httpUrl = it.request().url
+                val requestBuilder = it.request().newBuilder().url(httpUrl)
+                it.proceed(requestBuilder.build())
+            }
+            .addInterceptor(logInterceptor)
+            .readTimeout(10, TimeUnit.SECONDS)
+            .connectTimeout(10, TimeUnit.SECONDS)
+            .build()
+    }
+
+    @Provides
+    @Singleton
+    fun provideRetrofit(
+        okHttpClient: OkHttpClient,
+    ): Retrofit {
+        val moshi = Moshi.Builder()
+            .add(KotlinJsonAdapterFactory())
+            .build()
+        return Retrofit.Builder()
+            .client(okHttpClient)
+            .baseUrl("https://qiita.com/api/v2/")
+            .addConverterFactory(MoshiConverterFactory.create(moshi))
+            .build()
+    }
+
+    @Provides
+    @Singleton
+    fun provideQiitaService(retrofit: Retrofit): QiitaApi = retrofit.create(QiitaApi::class.java)
+
+}

--- a/repository/src/main/java/com/example/repository/QiitaRepository.kt
+++ b/repository/src/main/java/com/example/repository/QiitaRepository.kt
@@ -2,41 +2,22 @@ package com.example.repository
 
 import com.example.api.QiitaApi
 import com.example.model.Article
-import com.squareup.moshi.Moshi
-import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import retrofit2.Retrofit
-import retrofit2.converter.moshi.MoshiConverterFactory
 import timber.log.Timber
 import javax.inject.Inject
 
-class QiitaRepository @Inject constructor() {
-
-    private val moshi = Moshi.Builder()
-        .add(KotlinJsonAdapterFactory())
-        .build()
-
-    private val service: QiitaApi =
-        Retrofit.Builder()
-            .baseUrl("https://qiita.com/api/v2/")
-//            .addConverterFactory(GsonConverterFactory.create())
-            .addConverterFactory(MoshiConverterFactory.create(moshi))
-            .build()
-            .create(QiitaApi::class.java)
+class QiitaRepository @Inject constructor(
+    private val qiitaApi: QiitaApi
+) {
 
     // TODO : UseCaseでAPI呼び出す
     suspend fun getArticle(): List<Article>? {
         var qiitaData: List<Article>? = null
         withContext(Dispatchers.IO) {
             runCatching {
-//                val response = service.articleItems("Kotlin").execute()
-                val response = service.articleItems().execute()
-                if (response.isSuccessful) {
-                    qiitaData = response.body()!!
-                } else {
-                    Timber.d("Get Error")
-                }
+                qiitaData = qiitaApi.articleItems().body()
+
             }.onFailure {
                 Timber.d("API取得こけるログ：$it")
             }


### PR DESCRIPTION
# ◆問題
moshiを使用すると、APIレスポンスを受け取るときに、onFailureになってしまう現象

# ◆調査
色々調査したが、正直、根本原因はよくわからない。
ただ、DIのサイトを徘徊すると、ApiModuleを使用したやり方が、明確な差分となっていたため、そのやり方に合わせる対応を試みた

# ◆解決(PR作成)
ApiModuleを用いて、Retrofit2をQiitaApiにDIしたら、moshiでAPIレスポンスを受け取れるまで確認